### PR TITLE
ENG-784 Allow Docker image to run shell scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ RUN apk add --no-cache git
 
 COPY --from=builder /usr/src/app/target/release/amplify-runner /usr/bin/amplify-runner
 
-ENTRYPOINT ["/usr/bin/amplify-runner"]
+CMD ["/usr/bin/amplify-runner"]


### PR DESCRIPTION
Fixes execution on GitLab where components expect to run `sh` in the container, it appears:

```
Executing "step_script" stage of the job script 00:01
Using docker image sha256:2e44c784a9ab245ffd07972170ff7fd7a84a4684ecbdc583d52a6bd66f97c218 for amplifysecurity/runner:0.1 with digest amplifysecurity/runner@sha256:6c6726a0d5ab1659f7e4174cbc6e2f2cc0ccf542706d45a4cea7503b2c574f30 ...
Error: `sh` is not expected in this context
```

After change:

```
Executing "step_script" stage of the job script 00:01
Using docker image sha256:35b1ccc79e126f92d21044213d2490f39cd6e87670c290fab3605173474c5e31 for amplifysecurity/runner:sha-d4c5472 with digest amplifysecurity/runner@sha256:cc87305cf4e1d3b295e56046a4afca06910cb97bb462a6576be562192efd4fbe ...
$ /usr/bin/amplify-runner
<runner output>
```