### PR TITLE
Update Dockerfile to Rust 1.81/Alpine 3.20.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.80.0-alpine3.20 as builder
+FROM rust:1.81.0-alpine3.20 as builder
 
 WORKDIR /usr/src/app
 
@@ -9,7 +9,7 @@ COPY src ./src/
 RUN cargo build --release --locked
 RUN strip ./target/release/amplify-runner
 
-FROM alpine:3.20.2
+FROM alpine:3.20.3
 
 RUN apk add --no-cache git
 


### PR DESCRIPTION
Resolves [CVE-2024-6119](https://scout.docker.com/v/CVE-2024-6119?s=alpine&n=openssl&ns=alpine&t=apk&osn=alpine&osv=3.20&vr=%3C3.3.2-r0).
