### PR TITLE
ENG-944 Ensure pysemgrep is in PATH

### DIFF
--- a/src/amplify.rs
+++ b/src/amplify.rs
@@ -1,6 +1,7 @@
 use color_eyre::eyre::{eyre, Result, WrapErr};
 use enum_dispatch::enum_dispatch;
 use serde::{Deserialize, Serialize};
+use std::env;
 use std::process::Stdio;
 use tokio::process::Command;
 
@@ -139,9 +140,11 @@ impl ToolActions for Semgrep {
     async fn launch(&self) -> Result<(ArtifactType, String)> {
         // TODO: Split out command execution grouped output into helper functions
         println!("::group::semgrep ci (scan job)");
+        let search_paths: String = env::var("PATH").expect("Couldn't identify PATH.");
         let semgrep_scan = Command::new("/semgrep/bin/semgrep")
             // When public-api supports SARIF artifact ingestion, just change --json to --sarif here and update the return type
             .args(["ci", "--config", "auto", "--json", "--oss-only"])
+            .env("PATH", format!("{search_paths}:/semgrep/bin"))
             .env("SEMGREP_RULES", ["p/security-audit", "p/secrets"].join(" "))
             .env("SEMGREP_IN_DOCKER", "1")
             .env("SEMGREP_USER_AGENT_APPEND", "Docker")

--- a/src/amplify.rs
+++ b/src/amplify.rs
@@ -117,7 +117,7 @@ impl ToolActions for Semgrep {
             vec!["apk", "add", "python3", "py3-pip"],
             vec!["mkdir", "/semgrep"],
             vec!["python", "-m", "venv", "/semgrep"],
-            vec!["/semgrep/bin/pip", "install", "semgrep==1.93.0"],
+            vec!["/semgrep/bin/pip", "install", "semgrep==1.95.0"],
         ]
         .into_iter()
         {


### PR DESCRIPTION
Semgrep 1.94.0 moved the `semgrep` script from `bin/semgrep` to `src/semgrep/console_scripts/entrypoint.py` in https://github.com/semgrep/semgrep/pull/10639 (https://github.com/semgrep/semgrep/commit/9eee60510cdbfdb4c382c8945ed604bd978b496c), which dynamically updated the PATH based on where the script itself was located…so instead of `/semgrep/bin` getting added to the PATH, `/semgrep/lib/python3.12/site-packages/semgrep/console_scripts` did, which does not itself contain the `semgrep` and `pysemgrep` scripts (`pysemgrep` was renamed to `pysemgrep.py` in this folder—if it had remained the same we would’ve gotten lucky and this change would’ve flown under the radar).

This ensures the binary path (`setup.py` was redefined to create scripts that import the original ones in `console_scripts`) still gets added to PATH when launching Semgrep.